### PR TITLE
CSO-Visitor online connectivity established using channels breathing technique

### DIFF
--- a/home/consumers/cso_visitor_chat_consumer.py
+++ b/home/consumers/cso_visitor_chat_consumer.py
@@ -275,7 +275,7 @@ class CSOVisitorChatSuppportConsumer(WebsocketConsumer):
             # Disconnect the intruder's channel conn without saving his msg to db
             self.disconnect(self)
     
-    # This method will be called in the receive-method while sending msg to channel-group.
+    # [Custom Method] This method will be called in the receive-method while sending msg to channel-group.
     # "event" param contains other keys (except 'type' key) from inside the dictionary passed as param in "channel_layer.group_send"
     def chat_message(self, event):
         message = event['message']
@@ -288,6 +288,19 @@ class CSOVisitorChatSuppportConsumer(WebsocketConsumer):
             'user_identity': user_identity,
             'roomslug': roomslug,
         }))
+
+
+    # [Custom Method] To get the signal of the support is resolved from the "views\home_views.py" file's post-method of "CustomerSupportRoom" class-view
+    def support_resolved(self, event):
+        print('\n', '-'*50)
+        print('The support is resolved')
+        print('\n', '-'*50)
+        cso_email = event['cso_email']
+        self.send(text_data=json.dumps({
+            'support_is_resolved': 'The support is resolved!',
+            'cso_email': cso_email,
+        }))
+
 
     # Default method of "WebsocketConsumer" class
     def disconnect(self, *args, **kwargs):

--- a/home/signals.py
+++ b/home/signals.py
@@ -18,6 +18,7 @@ def customer_support_request_signal(sender, instance, created, **kwargs):
         # for sending the payload to each individual cso-channel's frontend wbSocket 
         # through "CSODashboardConsumer".
         channel_layer = get_channel_layer()
+        # TODO: This signal will be custom-made later, logic will be implemented here to decide in which cso-support-dashboard-channel the request will be sent to.
         async_to_sync(channel_layer.group_send)(
             'chat_dashboard',
             {

--- a/home/views/home_views.py
+++ b/home/views/home_views.py
@@ -7,6 +7,8 @@ from authenticationApp.models import User
 from datetime import date
 import datetime
 import uuid
+from channels.layers import get_channel_layer
+# from asgiref.sync import async_to_sync
 
 
 
@@ -126,6 +128,15 @@ class CustomerSupportRoom(View):
                 cso_visitor_convo_info.is_resolved, cso_visitor_convo_info.is_connected = True, False
                 cso_visitor_convo_info.save()
                 # print('Change the record\'s field: "is_resolved=True" & "is_connected=False"')
+                # # TODO: Send a signal to that socket-consumer about the chat-support is resolved.
+                # channel_layer = get_channel_layer()
+                # async_to_sync(channel_layer.group_send)(
+                #     f'chat_{room_slug}',
+                #     {
+                #         'type': 'support_resolved',
+                #         'cso_email': request.user.email
+                #     }
+                # )
         # TODO: Redirect the cso to his/her dashboard accordingly, then redirect the visitor to the homepage thorugh channel-connection automatic-btn-click with js from the visitor perspective in the "customerSupport.html" file.
         return redirect(reverse('staffApplication:CsoWorkload:SupportDashboard', kwargs={'email': request.user.email}))
         # return HttpResponse(f' \

--- a/templates/home/customerSupport.html
+++ b/templates/home/customerSupport.html
@@ -136,6 +136,10 @@
                 // window.location.replace(`{% url 'homeApp:LangingPage' %}`);  // works like render-redirect of dj (maybe)
             }
         }
+
+        if (data.support_is_resolved) {
+            console.log(`The support is resolved! Redirect the cso to it's dashboard & the visitor to the homepage!`)
+        }
     }
 
     // WEBSOCKET Close function


### PR DESCRIPTION
# Major Change
- Working with the ConvoInfo Record changing with the "**is_resolved**" button. (_If the CSO marks the conversation as resolved, the CSO & the corresponding visitor will be redirected accordingly to CSO dashboard & homepage. Signal will be raised using channels & webSocket._)

# Task
- Make the "**is_resolved**" button from "form:POST" method to a simple clickable button.